### PR TITLE
Bring HTTP API docs re/ metadata search from bigchaindb/bigchaindb repo to this repo

### DIFF
--- a/docs/protocol/source/http-api.rst
+++ b/docs/protocol/source/http-api.rst
@@ -458,6 +458,118 @@ Assets
                     text search.
 
 
+Transaction Metadata
+--------------------------------
+
+.. http:get:: /api/v1/metadata
+
+   Return all the metadata that match a given text search.
+
+   :query string text search: Text search string to query.
+   :query int limit: (Optional) Limit the number of returned metadata objects. Defaults
+                     to ``0`` meaning return all matching objects.
+
+   .. note::
+
+        Currently this enpoint is only supported if the server is running
+        MongoDB as the backend.
+
+.. http:get:: /api/v1/metadata/?search={text_search}
+
+    Return all metadata that match a given text search. The ``id`` of the metadata
+    is the same ``id`` of the transaction where it was defined.
+
+    If no metadata match the text search it returns an empty list.
+
+    If the text string is empty or the server does not support text search,
+    a ``400`` is returned.
+
+    The results are sorted by text score.
+    For more information about the behavior of text search see `MongoDB text
+    search behavior <https://docs.mongodb.com/manual/reference/operator/query/text/#behavior>`_
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+        GET /api/v1/metadata/?search=bigchaindb HTTP/1.1
+        Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+        HTTP/1.1 200 OK
+        Content-type: application/json
+
+        [
+            {
+                "metadata": {"metakey1": "Hello BigchainDB 1!"},
+                "id": "51ce82a14ca274d43e4992bbce41f6fdeb755f846e48e710a3bbb3b0cf8e4204"
+            },
+            {
+                "metadata": {"metakey2": "Hello BigchainDB 2!"},
+                "id": "b4e9005fa494d20e503d916fa87b74fe61c079afccd6e084260674159795ee31"
+            },
+            {
+                "metadata": {"metakey3": "Hello BigchainDB 3!"},
+                "id": "fa6bcb6a8fdea3dc2a860fcdc0e0c63c9cf5b25da8b02a4db4fb6a2d36d27791"
+            }
+        ]
+
+   :resheader Content-Type: ``application/json``
+
+   :statuscode 200: The query was executed successfully.
+   :statuscode 400: The query was not executed successfully. Returned if the
+                    text string is empty or the server does not support
+                    text search.
+
+.. http:get:: /api/v1/metadata/?search={text_search}&limit={n_documents}
+
+    Return at most ``n`` metadata objects that match a given text search.
+
+    If no metadata match the text search it returns an empty list.
+
+    If the text string is empty or the server does not support text search,
+    a ``400`` is returned.
+
+    The results are sorted by text score.
+    For more information about the behavior of text search see `MongoDB text
+    search behavior <https://docs.mongodb.com/manual/reference/operator/query/text/#behavior>`_
+
+   **Example request**:
+
+   .. sourcecode:: http
+
+    GET /api/v1/metadata/?search=bigchaindb&limit=2 HTTP/1.1
+    Host: example.com
+
+   **Example response**:
+
+   .. sourcecode:: http
+
+    HTTP/1.1 200 OK
+    Content-type: application/json
+
+    [
+        {
+            "metadata": {"msg": "Hello BigchainDB 1!"},
+            "id": "51ce82a14ca274d43e4992bbce41f6fdeb755f846e48e710a3bbb3b0cf8e4204"
+        },
+        {
+            "metadata": {"msg": "Hello BigchainDB 2!"},
+            "id": "b4e9005fa494d20e503d916fa87b74fe61c079afccd6e084260674159795ee31"
+        },
+    ]
+
+   :resheader Content-Type: ``application/json``
+
+   :statuscode 200: The query was executed successfully.
+   :statuscode 400: The query was not executed successfully. Returned if the
+                    text string is empty or the server does not support
+                    text search.
+
+
 Advanced Usage
 --------------------------------
 


### PR DESCRIPTION
This pull request replaces #31 

It does the same thing, but it has the proper Git attribution, with @kansi recorded as contributor to the commit!

How I did this:

1. I went to my local clone of the bigchaindb/bigchaindb repository and checked out the `bug/1592/metadata-text-search` branch, which is the branch where @kansi updated the documentation for the HTTP API to add the docs about the full-text metadata search
2. I made commit 4eca26782caac8c9f95b0ef4abd58f4a56f0c013 into a "patch file" (saved to my Desktop) using:
```bash
git format-patch -1 4eca26782caac8c9f95b0ef4abd58f4a56f0c013 -o ~/Desktop/
```
3. I opened that patch file in a text editor and removed all the diffs that were unrelated to the HTTP API documentation change. I saved the file.
4. I went to my local clone of the ipdb/ipdb-protocol repository and checked out a new branch `add-patch-with-metadata-search-api-docs`
5. I added the patch file (as a commit) to that branch using:
```bash
git am -3 < ~/Desktop/0001-Change-metadata-model-fix-tests-and-update-docs.patch
```

It seems like it worked!