### PR TITLE
Deleted version.py

### DIFF
--- a/bigchaindb/version.py
+++ b/bigchaindb/version.py
@@ -1,2 +1,0 @@
-__version__ = '1.2.0.dev'
-__short_version__ = '1.2.dev'


### PR DESCRIPTION
I was keeping version.py around so that the old Server and Root docs would still build, but I don't care about that any more, and I don't want anyone to think that it has any other meaning. I'm keeping the old Server and Root docs around for now so I can scavenge them easily. I'll delete them eventually.