### PR TITLE
Updated the instructions about how to build a valid tx

### DIFF
--- a/docs/transactions/source/construct-a-tx.rst
+++ b/docs/transactions/source/construct-a-tx.rst
@@ -26,6 +26,7 @@ This page lists the steps to construct a valid transaction.
 .. code-block:: bash
 
    {
+      "id": null,
       "version": version,
       "inputs": unfulfilled_inputs,
       "outputs": outputs,
@@ -33,6 +34,9 @@ This page lists the steps to construct a valid transaction.
       "asset": asset,
       "metadata": metadata
     }
+
+Note how ``unfulfilled_tx`` includes a key-value pair for the ``"id"`` key.
+The value must be your programming language's equivalent of :term:`null`.
 
 We will now convert ``unfulfilled_tx`` to something
 that can be signed:
@@ -58,11 +62,12 @@ that can be signed:
    by making a deep copy of ``unfulfilled_tx``.
 #. In ``tx``, change the value of ``"inputs"`` to the just-computed
    ``inputs`` (an array of fulfilled inputs).
-#. :ref:`Compute the transaction ID of tx <Transaction ID>`. Call it ``id``.
-#. Append a new key-value pair to ``tx``: ``{"id": id}``.
-   Call the result ``final_tx``.
+#. :ref:`Compute the transaction ID of tx <Transaction ID>`.
+   Call it ``computed_id``.
+#. In ``tx``, change the value of ``"id"`` to ``computed_id``.
 
-``final_tx`` is a valid fulfilled transaction.
+The final result (``tx``) is a valid fulfilled transaction
+(in the form of an associative array).
 To put it in the body of an HTTP POST request,
 you'll have to :ref:`convert it to a JSON string
 <JSON Serialization & Deserialization>`.

--- a/docs/transactions/source/construct-a-tx.rst
+++ b/docs/transactions/source/construct-a-tx.rst
@@ -3,11 +3,6 @@ How to Construct a Transaction
 
 This page lists the steps to construct a valid transaction.
 
-One begins by constructing an "unfulfilled transaction."
-It's the thing-that-gets-signed when computing all the
-cryptographic signatures needed
-to construct a valid "fulfilled transaction."
-
 #. Set a variable named ``version`` to a :ref:`valid version value
    <Version>`.
 #. Set a variable named ``operation`` to a :ref:`valid operation value
@@ -24,16 +19,13 @@ to construct a valid "fulfilled transaction."
    that should be in the transaction.
    All fulfillment strings should be set to
    the equivalent of :term:`null` in your programming language.
-   (We're building the unfulfilled transaction first.)
-#. Compute the :ref:`transaction ID <Transaction ID>`
-   and store it in a variable named ``id``.
-#. Construct an :term:`associative array` named ``tx1`` of the form
+   (We're building an "unfulfilled transaction" first.)
+#. Construct an :term:`associative array` named ``unfulfilled_tx`` of the form
    (based on JSON syntax):
 
 .. code-block:: bash
 
    {
-      "id": id,
       "version": version,
       "inputs": unfulfilled_inputs,
       "outputs": outputs,
@@ -42,29 +34,35 @@ to construct a valid "fulfilled transaction."
       "metadata": metadata
     }
 
-The result (``tx1``) is the :term:`associative array` form
-of an "unfulfilled transaction."
-We use that to construct the associated fulfilled transaction:
+We will now convert ``unfulfilled_tx`` to something
+that can be signed:
 
-#. :ref:`Convert tx1 to an IPDB standard JSON string
-   <JSON Serialization & Deserialization>` named ``tx1_json``.
-#. :ref:`Convert tx1_json to bytes <Converting Strings to Bytes>`.
-   Call the result ``tx1_bytes``.
+#. :ref:`Convert unfulfilled_tx to an IPDB-standard JSON string
+   <JSON Serialization & Deserialization>` named ``utx_json``.
+#. :ref:`Convert utx_json to bytes <Converting Strings to Bytes>`.
+   Call the result ``utx_bytes``.
+
+``utx_bytes`` can be signed to compute all signatures and fulfillment strings.
+
 #. Create ``inputs`` as a deep copy of ``unfulfilled_inputs``.
 #. For each input in ``inputs``,
-   fulfill the associated crypto condition
-   `using an implementation of crypto conditions
+   fulfill the associated crypto-condition
+   `using an implementation of crypto-conditions
    <https://github.com/rfcs/crypto-conditions#implementations>`_.
-   You will need ``tx1_bytes`` and one or more private keys
-   (which are used to sign ``tx1_bytes``).
+   You will need ``utx_bytes`` and one or more private keys
+   (which are used to sign ``utx_bytes``).
    The end result is usually some kind of fulfilled condition object.
    Compute the fulfillment string of that fulfilled condition object, and
    put that as the value of ``"fulfillment"`` for the input in question.
-#. Construct ``tx2`` by making a deep copy of ``tx1``
-   and setting the value of the ``"inputs"`` key to ``inputs``.
+#. Construct a new :term:`associative array` ``tx``
+   by making a deep copy of ``unfulfilled_tx``.
+#. In ``tx``, change the value of ``"inputs"`` to the just-computed
+   ``inputs`` (an array of fulfilled inputs).
+#. :ref:`Compute the transaction ID of tx <Transaction ID>`. Call it ``id``.
+#. Append a new key-value pair to ``tx``: ``{"id": id}``.
+   Call the result ``final_tx``.
 
-The result (``tx2``) is the :term:`associative array` form
-of a valid fulfilled transaction.
+``final_tx`` is a valid fulfilled transaction.
 To put it in the body of an HTTP POST request,
 you'll have to :ref:`convert it to a JSON string
 <JSON Serialization & Deserialization>`.
@@ -76,4 +74,4 @@ The documentation of the BigchainDB Python Driver has a page titled
 `"Handcrafting Transactions"
 <https://docs.bigchaindb.com/projects/py-driver/en/latest/handcraft.html>`_
 which shows how to do all of the above
-in Python (using a Python implementation of crypto conditions).
+in Python (using a Python implementation of crypto-conditions).

--- a/docs/transactions/source/transaction-components/transaction-id.rst
+++ b/docs/transactions/source/transaction-components/transaction-id.rst
@@ -16,6 +16,7 @@ Here are the steps to compute it.
 .. code-block:: bash
 
    {
+      "id": null,
       "version": version,
       "inputs": inputs,
       "outputs": outputs,
@@ -24,7 +25,8 @@ Here are the steps to compute it.
       "metadata": metadata
     }
 
-Note how ``d`` is missing the ``"id"`` key and value.
+Note how ``d`` includes a key-value pair for the ``"id"`` key.
+The value must be your programming language's equivalent of :term:`null`.
 
 2. Compute ``id = hash_of_aa(d)``. There's pseudocode for the ``hash_of_aa()`` function
    on :ref:`the page about cryptographic hashes <Computing the Hash of an Associative Array>`.

--- a/docs/transactions/source/transaction-components/transaction-id.rst
+++ b/docs/transactions/source/transaction-components/transaction-id.rst
@@ -10,7 +10,8 @@ An example is:
 
 Here are the steps to compute it.
 
-1. Construct an :term:`associative array` named ``d`` like:
+1. Construct an :term:`associative array` named ``d`` of the form
+   (based on JSON syntax):
 
 .. code-block:: bash
 
@@ -23,11 +24,8 @@ Here are the steps to compute it.
       "metadata": metadata
     }
 
-Note how ``d`` is missing the "id" key and value.
+Note how ``d`` is missing the ``"id"`` key and value.
 
-2. In ``d``, for each of the inputs in ``inputs``, replace the value of each ``fulfillment``
-   with the equivalent of :term:`null` in your programming language.
-   Call the resulting associative array ``d2``.
-3. Compute ``id = hash_of_aa(d2)``. There's pseudocode for the ``hash_of_aa()`` function
+2. Compute ``id = hash_of_aa(d)``. There's pseudocode for the ``hash_of_aa()`` function
    on :ref:`the page about cryptographic hashes <Computing the Hash of an Associative Array>`.
    The result (``id``) is a string: the transaction ID.


### PR DESCRIPTION
We've changed how to build a valid transaction in version 2.0 of the transaction spec. Now we sign (fulfill) first and compute the transaction ID (i.e. hash the transaction) last.

@sbellem I'm not sure of some things. Please read the steps with a critical eye. In particular:

1. When constructing the thing-to-be signed (i.e. a transaction with no id yet, and with all fulfillments set to null), do you have a key-value pair of the form {"id": null} in there, or do you have no "id" key and value in there at all?
2. Before signing `utx_bytes` (i.e. the bytes of the unfulfilled transaction), do you first compute a hash of `utx_bytes` and sign _that_? I think you mentioned something like this. If the answer is yes, is it a SHA3-256 hash?
