### PR TITLE
Example Transactions page now points to docs elsewhere

### DIFF
--- a/docs/transactions/source/example-transactions.rst
+++ b/docs/transactions/source/example-transactions.rst
@@ -1,43 +1,13 @@
 Example Transactions
 ====================
 
-Here's an example CREATE transaction as JSON:
+You can find examples of BigchainDB transactions in:
 
-.. code-block:: json
+- `the Python driver documentation
+  <https://docs.bigchaindb.com/projects/py-driver/en/latest/index.html>`_
+- `the JavaScript driver documentation
+  <https://docs.bigchaindb.com/projects/js-driver/en/latest/index.html>`_
+- `the docs about the HTTP API in the docs for BigchainDB Server
+  <https://docs.bigchaindb.com/projects/server/en/latest/http-client-server-api.html>`_
 
-    {
-        "id": "0e7a9a9047fdf39eb5ead7170ec412c6bffdbe8d7888966584b4014863e03518",
-        "version": "1.0",
-        "inputs": [
-            {
-                "fulfillment": "pGSAIL3aH9oajqk9K5LERXeCNtT-rm_saYXg6IIjlBfWNCLOgUAVgaGMUNF4rKVWeFmGphwJls45cZxttqa-9UKfSGOlLS_80dwsfa3hIo9dC00ojV1xeOGR6AAxU7BIyhJ3j6sH",
-                "fulfills": null,
-                "owners_before": [
-                    "Dn6xz1F9Toy5qbaZUASsvTAUB78HEHs5YPrx6Pd5yu5P"
-                ]
-            }
-        ],
-        "outputs": [
-            {
-                "amount": "1",
-                "condition": {
-                    "uri": "ni:///sha-256;CNXDAYaEJD1l0hO21ZpLIdjrWZIeE2V9xxuNcZ10Lo8?fpt=ed25519-sha-256&cost=131072",
-                    "details": {
-                        "public_key": "Dn6xz1F9Toy5qbaZUASsvTAUB78HEHs5YPrx6Pd5yu5P",
-                        "type": "ed25519-sha-256"
-                    }
-                },
-                "public_keys": [
-                    "Dn6xz1F9Toy5qbaZUASsvTAUB78HEHs5YPrx6Pd5yu5P"
-                ]
-            }
-        ],
-        "operation": "CREATE",
-        "asset": {
-            "data": {
-                "time": "09:01:01 10/30/17 CET",
-                "type": "test asset"
-            }
-        },
-        "metadata": null
-    }
+Just remember to check the value of ``"version"`` in the transaction.


### PR DESCRIPTION
The Example Transactions page now points to docs elsewhere, rather than having one static example.

(I removed the old example version 1.0 CREATE transaction.)

Maybe in the future, we can auto-generate some example transactions using the appropriate `bigchaindb` package, but right now there isn't one available to generate an example version 2.0 transaction.