### PR TITLE
Various minor corrections to the docs

### DIFF
--- a/docs/transactions/source/implementation-deviations.rst
+++ b/docs/transactions/source/implementation-deviations.rst
@@ -10,8 +10,10 @@ BigchainDB Server
 -----------------
 
 `BigchainDB Server <https://github.com/bigchaindb/bigchaindb>`_
-is an IPDB-compliant server
-implemented in Python.
+is an IPDB-compliant server implemented in Python.
+
+It allows :ref:`operation <Operation>` to have the value ``"GENESIS"``,
+but only for transactions in the GENESIS block.
 
 
 BigchainDB Server with MongoDB

--- a/docs/transactions/source/transaction-components/operation.rst
+++ b/docs/transactions/source/transaction-components/operation.rst
@@ -1,13 +1,15 @@
 Operation
 =========
 
-A string indicating what kind of transaction this is,
+The operation indicates the type/kind of transaction,
 and how it should be validated.
-The allowed values are ``"CREATE"``, ``"TRANSFER"`` and ``"GENESIS"``
-(but there should only be one transaction whose operation is ``"GENESIS"``:
-the one in the GENESIS block).
+It must be a string.
+The allowed values are ``"CREATE"`` and ``"TRANSFER"``.
 
 .. note::
 
-   The ``"GENESIS"`` transaction might be deprecated in future versions
-   of the IPDB Transaction Spec.
+   Some implementations may allow other values,
+   but maybe only internally.
+   For example, BigchainDB Server allows the value ``"GENESIS"``.
+   See :ref:`the page about implementation-specific deviations
+   <Implementation-Specific Deviations>`.

--- a/docs/transactions/source/transaction-components/transaction-id.rst
+++ b/docs/transactions/source/transaction-components/transaction-id.rst
@@ -2,7 +2,7 @@ Transaction ID
 ==============
 
 The ID of a transaction is the SHA3-256 hash
-of the unsigned transaction, loosely speaking.
+of the transaction, loosely speaking.
 It's a string.
 An example is:
 

--- a/docs/transactions/source/transaction-components/version.rst
+++ b/docs/transactions/source/transaction-components/version.rst
@@ -1,11 +1,13 @@
 Version
 =======
 
-The value of ``"version"`` indicates how the transaction
-should be validated.
+The version indicates the transaction validation rules
+to be used when validating the transaction,
+i.e. the rules associated with that version
+of the IPDB Transaction Spec.
 It must be a string.
 
-If the value is ``"2.0"``,
+For example, if the value is ``"2.0"``,
 then the transaction will be validated according
 the :ref:`transaction validation rules <Transaction Validation>`
 of version 2.0.0 of the IPDB Transaction Spec.


### PR DESCRIPTION
- The fact that operation can be "GENESIS" is non-standard. It's a deviation specific to BigchainDB Server.
- A minor fix to page about Transaction ID.
- Copy-editing the page about "version".
