### PR TITLE
Renamed all index.md files to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This repository contains the IPDB Transaction Spec (specification).
 
-Version 2.0 of the spec is in the file [v2.0/index.md](./v2.0/index.md). Other versions are in other subdirectories.
+Version 2.0 of the spec is in the file [v2.0/README.md](./v2.0/README.md). Other versions are in other subdirectories.
 
 The `docs/` directory is where the spec source files were located in the past. Don't delete it yet.
 

--- a/v1.0/README.md
+++ b/v1.0/README.md
@@ -55,7 +55,7 @@ In the rest of this document, "transaction" almost always means "IPDB transactio
 
 ## Versioning
 
-The IPDB Transaction Spec has several versions (e.g. version 1.0, version 2.0, etc.). Each one is documented completely in one Markdown file. For example, version 1.0 is documented in the file `v1.0/index.md`.
+The IPDB Transaction Spec has several versions (e.g. version 1.0, version 2.0, etc.). Each one is documented completely in one Markdown file. For example, version 1.0 is documented in the file `v1.0/README.md`.
 
 When is a new version created?
 

--- a/v2.0/README.md
+++ b/v2.0/README.md
@@ -55,7 +55,7 @@ In the rest of this document, "transaction" almost always means "IPDB transactio
 
 ## Versioning
 
-The IPDB Transaction Spec has several versions (e.g. version 1.0, version 2.0, etc.). Each one is documented completely in one Markdown file. For example, version 1.0 is documented in the file `v1.0/index.md`.
+The IPDB Transaction Spec has several versions (e.g. version 1.0, version 2.0, etc.). Each one is documented completely in one Markdown file. For example, version 1.0 is documented in the file `v1.0/README.md`.
 
 When is a new version created?
 


### PR DESCRIPTION
Because GitHub renders a directory's README.md file by default, right on the directory's page, saving a mouse click. :smile: 
